### PR TITLE
Add Laravel 7.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require":           {
         "php":                ">=5.5.0",
-        "illuminate/support": "5.*|6.*",
+        "illuminate/support": "5.*|6.*|7.*",
         "intouch/newrelic":   ">=1.0.2"
     },
     "require-dev":       {


### PR DESCRIPTION
The library doesn't currently support Laravel 7.x

We form the library since it wasn't supporting Laravel 6.x